### PR TITLE
Use Rails models when passing in manual configurations.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,23 @@
 # Changelog
 
+# 0.1.0 (Planned)
+
+* Switch to using Rails models rather than table names.
+
+You must now specify rails models in your manual_configuration.
+
+Remember, if you want to configure all models, you must eager load in development.
+
+```
+  Rails.application.eager_load!
+  Rails::Engine.subclasses.map(&:eager_load!)
+```
+
+* Reject polymorphic relationships from ever being a candidate parent.
+
+This has the implication that a table that wasn't considered top level could be
+top level.
+
 ## 0.0.6
 
 Allow manual_configuration to transition to using model names (moving off from table names)

--- a/README.md
+++ b/README.md
@@ -18,15 +18,22 @@ You can specify manual configurations if needed.
 
 ```
 manual_configuration = [
-  ["users", nil, User.where(:id => [1])],      # specify a subset of users. as users have no parent, specify `nil`
-  ["blog_posts", User]                         # filter blog_posts by User
+  [User, nil, User.where(:id => [1])],     # specify a subset of users. as users have no parent, specify `nil`
+  [BlogPost, User]                         # filter blog_posts by User
 ]
 ```
 
 TODO :
 
 * Rename PartialKs::ConfigurationGenerator#call to something better
-* What in the world is the tuples in `manual_configuration` meant to be ?
 * Minimize Public API
+* Tool to run report using bundle exec
+
+# Not supported
+
+Things that are not supported in this version.
+
+* Polymorphic relationships
+* Tables with STI
 
 

--- a/lib/partial_ks.rb
+++ b/lib/partial_ks.rb
@@ -3,6 +3,7 @@ require 'active_record'
 module PartialKs
 end
 
+require_relative 'partial_ks/all_rails_models'
 require_relative 'partial_ks/filtered_table'
 require_relative 'partial_ks/parent_inferrer'
 require_relative 'partial_ks/runner'

--- a/lib/partial_ks/all_rails_models.rb
+++ b/lib/partial_ks/all_rails_models.rb
@@ -1,0 +1,9 @@
+module PartialKs
+  def self.all_rails_models
+    if defined?(Rails)
+      ::Rails.application.eager_load!
+      ::Rails::Engine.subclasses.map(&:eager_load!)
+    end
+    ActiveRecord::Base.direct_descendants
+  end
+end

--- a/lib/partial_ks/parent_inferrer.rb
+++ b/lib/partial_ks/parent_inferrer.rb
@@ -7,11 +7,11 @@ class PartialKs::ParentInferrer
     @table = table
   end
 
-  def inferred_parent_table
+  def inferred_parent_class
     if table.top_level_table?
       nil
-    elsif table.non_nullable_parent_tables.size == 1
-      table.non_nullable_parent_tables.first
+    elsif table.candidate_parent_classes.size == 1
+      table.candidate_parent_classes.first
     else
       raise CannotInfer, "table has multiple candidates for parents"
     end

--- a/test/configuration_generator_test.rb
+++ b/test/configuration_generator_test.rb
@@ -1,9 +1,5 @@
 require 'test_helper'
 
-def pks_tables(*args)
-  args
-end
-
 def generator(manual, tables)
   PartialKs::ConfigurationGenerator.new(manual, tables).call.
     map {|f| [f.table_name, f.parent_model, f.custom_filter_relation] }
@@ -12,36 +8,12 @@ end
 describe "generating dependencies" do
   let(:manual_configuration) do
     [
-      ["users", nil, User.where(:id => [1])],
-    ]
-  end
-
-  it "auto infers single belongs-to dependencies" do
-    generator(manual_configuration, table_names: pks_tables("users", "blog_posts")).
-      must_equal [
-      ["users", nil, User.where(:id => [1])],
-      ["blog_posts", User, nil]
-    ]
-  end
-
-  it "auto infers top level tables" do
-    generator(manual_configuration, table_names: pks_tables("users", "tags")).
-      must_equal [
-      ["users", nil, User.where(:id => [1])],
-      ["tags", nil, nil]
-    ]
-  end
-end
-
-describe "transition to model based dependencies" do
-  let(:manual_configuration) do
-    [
       [User, nil, User.where(:id => [1])],
     ]
   end
 
   it "auto infers single belongs-to dependencies" do
-    generator(manual_configuration, table_names: pks_tables("users", "blog_posts")).
+    generator(manual_configuration, models: [User, BlogPost]).
       must_equal [
       ["users", nil, User.where(:id => [1])],
       ["blog_posts", User, nil]
@@ -49,10 +21,21 @@ describe "transition to model based dependencies" do
   end
 
   it "auto infers top level tables" do
-    generator(manual_configuration, table_names: pks_tables("users", "tags")).
+    generator(manual_configuration, models: [User, Tag]).
       must_equal [
       ["users", nil, User.where(:id => [1])],
       ["tags", nil, nil]
+    ]
+  end
+
+  it "can infer models with different table_name" do
+    model = OldEntry
+    model.table_name.wont_equal model.name.tableize
+
+    generator(manual_configuration, models: [User, model]).
+      must_equal [
+      ["users", nil, User.where(:id => [1])],
+      ["cms_table", nil, nil]
     ]
   end
 end

--- a/test/filtered_table_test.rb
+++ b/test/filtered_table_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 describe "filter condition" do
-  let(:table) { PartialKs::Table.new("users") }
+  let(:table) { PartialKs::Table.new(User) }
 
   it "uses parent as the filter" do
     parent = Tag

--- a/test/parent_inferrer_test.rb
+++ b/test/parent_inferrer_test.rb
@@ -2,17 +2,17 @@ require 'test_helper'
 
 describe "inferring parents" do
   it "infers no parent for a top level table" do
-    table = PartialKs::Table.new("tags")
-    PartialKs::ParentInferrer.new(table).inferred_parent_table.must_be_nil
+    table = PartialKs::Table.new(Tag)
+    PartialKs::ParentInferrer.new(table).inferred_parent_class.must_be_nil
   end
 
   it "infers a parent for a table that has a single belongs_to" do
-    table = PartialKs::Table.new("blog_posts")
-    PartialKs::ParentInferrer.new(table).inferred_parent_table.must_equal "users"
+    table = PartialKs::Table.new(BlogPost)
+    PartialKs::ParentInferrer.new(table).inferred_parent_class.must_equal User
   end
 
   it "infers no parent for a table has multiple belongs_to" do
-    table = PartialKs::Table.new("post_tags")
-    lambda { PartialKs::ParentInferrer.new(table).inferred_parent_table }.must_raise PartialKs::ParentInferrer::CannotInfer
+    table = PartialKs::Table.new(PostTag)
+    lambda { PartialKs::ParentInferrer.new(table).inferred_parent_class }.must_raise PartialKs::ParentInferrer::CannotInfer
   end
 end

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -18,9 +18,9 @@ describe 'running based on output from generator' do
 
   let(:generator_output) do
     [
-      PartialKs::FilteredTable.new(PartialKs::Table.new("users"), nil, custom_filter_relation: User.where(:id => [1])),
-      PartialKs::FilteredTable.new(PartialKs::Table.new("tags"), nil),
-      PartialKs::FilteredTable.new(PartialKs::Table.new("blog_posts"), User),
+      PartialKs::FilteredTable.new(PartialKs::Table.new(User), nil, custom_filter_relation: User.where(:id => [1])),
+      PartialKs::FilteredTable.new(PartialKs::Table.new(Tag), nil),
+      PartialKs::FilteredTable.new(PartialKs::Table.new(BlogPost), User),
     ]
   end
 

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -20,4 +20,9 @@ ActiveRecord::Schema.define(:version => 0) do
     t.references :tag, null: false
     t.timestamps null: false
   end
+
+  create_table :cms_table, :force => true do |t|
+    t.string :cms_id
+    t.string :some_legacy_thing
+  end
 end

--- a/test/setup_models.rb
+++ b/test/setup_models.rb
@@ -12,3 +12,7 @@ class PostTag < ActiveRecord::Base
   belongs_to :blog_post
   belongs_to :tag
 end
+
+class OldEntry < ActiveRecord::Base
+  self.table_name = "cms_table"
+end

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -3,8 +3,16 @@ require 'test_helper'
 describe PartialKs::Table do
   describe "#model" do
     it "has a model" do
-      table = PartialKs::Table.new("users")
+      table = PartialKs::Table.new(User)
       table.must_respond_to :model
+    end
+  end
+
+  describe "candidate parents" do
+    it "returns nothing for a top level table" do
+      table = PartialKs::Table.new(User)
+
+      table.candidate_parent_classes.must_equal []
     end
   end
 end


### PR DESCRIPTION
Aside from being cleaner, addresses the issue of table_names that
are not using rails conventions. In other words, closes #2

Within the internals use rails models as well.

Reject polymorphic relationships from ever being a candidate parent, due to
an issue in Rails that causes olymorphic relationships to always raise an
exception.