### PR TITLE
Fix foreign key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ Remember, if you want to configure all models, you must eager load in developmen
 This has the implication that a table that wasn't considered top level could be
 top level.
 
+* Bugfix: Emit valid where SQL fragments for models which has a assocation with `:foreign_key`
+that does not follow convention
+
 ## 0.0.6
 
 Allow manual_configuration to transition to using model names (moving off from table names)

--- a/lib/partial_ks/filtered_table.rb
+++ b/lib/partial_ks/filtered_table.rb
@@ -11,4 +11,21 @@ class PartialKs::FilteredTable
   def filter_condition
     custom_filter_relation || parent_model
   end
+
+  def kitchen_sync_filter
+    if !filter_condition.nil?
+      if filter_condition.is_a?(ActiveRecord::Relation) || filter_condition.respond_to?(:where_sql)
+        only_filter = filter_condition.where_sql.to_s.sub("WHERE", "")
+      elsif filter_condition.is_a?(String)
+        only_filter = filter_condition
+      else
+        # this only supports parents where it's a belongs_to
+        # TODO we can make it work with has_many
+        # e.g. SomeModel.reflect_on_association(:elses)
+        only_filter = "#{filter_condition.to_s.foreign_key} IN (#{[0, *filter_condition.pluck(:id)].join(',')})"
+      end
+
+      {"only" => only_filter}
+    end
+  end
 end

--- a/lib/partial_ks/filtered_table.rb
+++ b/lib/partial_ks/filtered_table.rb
@@ -20,7 +20,10 @@ class PartialKs::FilteredTable
         # this only supports parents where it's a belongs_to
         # TODO we can make it work with has_many
         # e.g. SomeModel.reflect_on_association(:elses)
-        only_filter = "#{filter_condition.to_s.foreign_key} IN (#{[0, *filter_condition.pluck(:id)].join(',')})"
+        association = table.model.reflect_on_all_associations(:belongs_to).find {|assoc| assoc.class_name == filter_condition.name}
+        raise "#{filter_condition.name} not found in #{table.model.name} associations" if association.nil?
+
+        only_filter = "#{association.foreign_key} IN (#{[0, *filter_condition.pluck(:id)].join(',')})"
       end
 
       {"only" => only_filter}

--- a/lib/partial_ks/filtered_table.rb
+++ b/lib/partial_ks/filtered_table.rb
@@ -8,11 +8,9 @@ class PartialKs::FilteredTable
     @custom_filter_relation = custom_filter_relation
   end
 
-  def filter_condition
-    custom_filter_relation || parent_model
-  end
-
   def kitchen_sync_filter
+    filter_condition = custom_filter_relation || parent_model
+
     if !filter_condition.nil?
       if filter_condition.is_a?(ActiveRecord::Relation) || filter_condition.respond_to?(:where_sql)
         only_filter = filter_condition.where_sql.to_s.sub("WHERE", "")

--- a/lib/partial_ks/runner.rb
+++ b/lib/partial_ks/runner.rb
@@ -12,21 +12,10 @@ class PartialKs::Runner
 
       generation.each do |table|
         table_names << table.table_name
-        filter_config = table.filter_condition
+        filter_config = table.kitchen_sync_filter
 
         if !filter_config.nil?
-          if filter_config.is_a?(ActiveRecord::Relation) || filter_config.respond_to?(:where_sql)
-            only_filter = filter_config.where_sql.to_s.sub("WHERE", "")
-          elsif filter_config.is_a?(String)
-            only_filter = filter_config
-          else
-            # this only supports parents where it's a belongs_to
-            # TODO we can make it work with has_many
-            # e.g. SomeModel.reflect_on_association(:elses)
-            only_filter = "#{filter_config.to_s.foreign_key} IN (#{[0, *filter_config.pluck(:id)].join(',')})"
-          end
-
-          tables_to_filter[table.table_name] = {"only" => only_filter}
+          tables_to_filter[table.table_name] = filter_config
         end
       end
 

--- a/lib/partial_ks/runner.rb
+++ b/lib/partial_ks/runner.rb
@@ -28,7 +28,7 @@ class PartialKs::Runner
     result = []
     each_generation.with_index do |generation, depth|
       generation.each do |table|
-        result << [table.table_name, table.parent_model, table.filter_condition, depth]
+        result << [table.table_name, table.parent_model, table.parent_model || table.custom_filter_relation, depth]
       end
     end
     result

--- a/test/filtered_table_test.rb
+++ b/test/filtered_table_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 describe "kitchen sync filter" do
-  let(:table) { PartialKs::Table.new(User) }
+  let(:table) { PartialKs::Table.new(PostTag) }
 
   it "uses parent as the filter" do
     parent = Tag
@@ -10,13 +10,22 @@ describe "kitchen sync filter" do
   end
 
   it "uses the custom filter if provided" do
-    filter = User.where(:id => [1, 2])
+    filter = PostTag.where(:id => [1, 2])
     filtered_table = PartialKs::FilteredTable.new(table, nil, custom_filter_relation: filter)
-    filtered_table.kitchen_sync_filter.must_equal({"only" => ' "users"."id" IN (1, 2)'})
+    filtered_table.kitchen_sync_filter.must_equal({"only" => ' "post_tags"."id" IN (1, 2)'})
   end
 
   it "returns nil if parent is nil" do
     filtered_table = PartialKs::FilteredTable.new(table, nil)
     filtered_table.kitchen_sync_filter.must_be_nil
+  end
+
+  describe "table with different :foreign_key" do
+    let(:table) { PartialKs::Table.new(OldTag) }
+
+    it "uses the foreign key that's present in the table" do
+      filtered_table = PartialKs::FilteredTable.new(table, OldEntry)
+      filtered_table.kitchen_sync_filter.must_equal({"only" => 'blog_post_id IN (0)'})
+    end
   end
 end

--- a/test/filtered_table_test.rb
+++ b/test/filtered_table_test.rb
@@ -20,3 +20,24 @@ describe "filter condition" do
     filtered_table.filter_condition.must_be_nil
   end
 end
+
+describe "kitchen sync filter" do
+  let(:table) { PartialKs::Table.new(User) }
+
+  it "uses parent as the filter" do
+    parent = Tag
+    filtered_table = PartialKs::FilteredTable.new(table, parent)
+    filtered_table.kitchen_sync_filter.must_equal({"only" => 'tag_id IN (0)'})
+  end
+
+  it "uses the custom filter if provided" do
+    filter = User.where(:id => [1, 2])
+    filtered_table = PartialKs::FilteredTable.new(table, nil, custom_filter_relation: filter)
+    filtered_table.kitchen_sync_filter.must_equal({"only" => ' "users"."id" IN (1, 2)'})
+  end
+
+  it "returns nil if parent is nil" do
+    filtered_table = PartialKs::FilteredTable.new(table, nil)
+    filtered_table.kitchen_sync_filter.must_be_nil
+  end
+end

--- a/test/filtered_table_test.rb
+++ b/test/filtered_table_test.rb
@@ -1,26 +1,5 @@
 require 'test_helper'
 
-describe "filter condition" do
-  let(:table) { PartialKs::Table.new(User) }
-
-  it "uses parent as the filter" do
-    parent = Tag
-    filtered_table = PartialKs::FilteredTable.new(table, parent)
-    filtered_table.filter_condition.must_equal parent
-  end
-
-  it "uses the custom filter if provided" do
-    filter = User.where(:id => 1)
-    filtered_table = PartialKs::FilteredTable.new(table, nil, custom_filter_relation: filter)
-    filtered_table.filter_condition.must_equal filter
-  end
-
-  it "returns nil if parent is nil" do
-    filtered_table = PartialKs::FilteredTable.new(table, nil)
-    filtered_table.filter_condition.must_be_nil
-  end
-end
-
 describe "kitchen sync filter" do
   let(:table) { PartialKs::Table.new(User) }
 

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -45,7 +45,7 @@ describe 'running based on output from generator' do
   end
 
   it "yields all non-null filters" do
-    expected_filters     = generator_output.each_with_object({}) {|ft, hash| hash[ft.table_name] = ft.filter_condition if ft.filter_condition}
+    expected_filters     = generator_output.each_with_object({}) {|ft, hash| hash[ft.table_name] = ft.kitchen_sync_filter if ft.kitchen_sync_filter}
     actual_filters       = {}
 
     runner.run! do |tables_to_filter, table_names|
@@ -55,7 +55,7 @@ describe 'running based on output from generator' do
     actual_filters.size.must_equal expected_filters.size
     actual_filters.keys.must_equal expected_filters.keys
     expected_filters.each do |table_name, filter_condition|
-      actual_filters[table_name]["only"].must_be_kind_of String    # TODO test different kinds of filters.
+      actual_filters[table_name]["only"].must_be_kind_of String
     end
   end
 end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -25,4 +25,9 @@ ActiveRecord::Schema.define(:version => 0) do
     t.string :cms_id
     t.string :some_legacy_thing
   end
+
+  create_table :old_tags, :force => true do |t|
+    t.integer :blog_post_id
+    t.timestamps null: false
+  end
 end

--- a/test/setup_models.rb
+++ b/test/setup_models.rb
@@ -16,3 +16,7 @@ end
 class OldEntry < ActiveRecord::Base
   self.table_name = "cms_table"
 end
+
+class OldTag < ActiveRecord::Base
+  belongs_to :old_entry, :foreign_key => 'blog_post_id'
+end


### PR DESCRIPTION
Fixes #5 

 Bugfix: Emit valid where SQL fragments for models which has a assocation with `:foreign_key` that does not follow convention