### PR TITLE
Do not attempt to process models where its table is missing from the database

### DIFF
--- a/lib/partial_ks/configuration_generator.rb
+++ b/lib/partial_ks/configuration_generator.rb
@@ -16,7 +16,11 @@ module PartialKs
 
     protected
     def all_tables
-      @all_tables ||= models.map {|model| PartialKs::Table.new(model) }.select(&:model?).index_by(&:table_name)
+      @all_tables ||= models.select{|model| tables_in_database.include?(model.table_name)}.map {|model| PartialKs::Table.new(model) }.select(&:model?).index_by(&:table_name)
+    end
+
+    def tables_in_database
+      @tables_in_database ||= ActiveRecord::Base.connection.tables
     end
 
     def filtered_tables

--- a/lib/partial_ks/configuration_generator.rb
+++ b/lib/partial_ks/configuration_generator.rb
@@ -3,7 +3,7 @@
 # and attempts to automatically populate the table into the table graph
 module PartialKs
   class ConfigurationGenerator
-    attr_reader :manual_configuration, :models
+    attr_reader :manual_configuration
 
     def initialize(manual_configuration, models: nil)
       @manual_configuration = manual_configuration
@@ -16,11 +16,12 @@ module PartialKs
 
     protected
     def all_tables
-      @all_tables ||= models.select{|model| tables_in_database.include?(model.table_name)}.map {|model| PartialKs::Table.new(model) }.select(&:model?).index_by(&:table_name)
+      @all_tables ||= models.map {|model| PartialKs::Table.new(model) }.select(&:model?).index_by(&:table_name)
     end
 
-    def tables_in_database
-      @tables_in_database ||= ActiveRecord::Base.connection.tables
+    def models
+      tables_in_database = ActiveRecord::Base.connection.tables
+      @models.select{|model| tables_in_database.include?(model.table_name)}
     end
 
     def filtered_tables

--- a/test/configuration_generator_test.rb
+++ b/test/configuration_generator_test.rb
@@ -38,4 +38,11 @@ describe "generating dependencies" do
       ["cms_table", nil, nil]
     ]
   end
+
+  it "does not choke on a table which has had its migration run" do
+    generator(manual_configuration, models: [User, NewModel]).
+      must_equal [
+      ["users", nil, User.where(:id => [1])],
+    ]
+  end
 end

--- a/test/setup_models.rb
+++ b/test/setup_models.rb
@@ -23,3 +23,8 @@ end
 class OldTag < ActiveRecord::Base
   belongs_to :old_entry, :foreign_key => 'blog_post_id'
 end
+
+class NewModel < ActiveRecord::Base
+  # no tables, e.g. migration not run yet
+  belongs_to :user
+end


### PR DESCRIPTION
This could be either the migration has not run, or the results of a kitchen sync --structure
meant that the table was removed. The latter use case is actually quite common,
where the remote database would not have a new-ish database table yet compared to the local
database.

Fixes #12