### PR TITLE
Support the new ApplicationRecord abstract_class convention

### DIFF
--- a/lib/partial_ks/all_rails_models.rb
+++ b/lib/partial_ks/all_rails_models.rb
@@ -4,6 +4,12 @@ module PartialKs
       ::Rails.application.eager_load!
       ::Rails::Engine.subclasses.map(&:eager_load!)
     end
-    ActiveRecord::Base.direct_descendants
+
+    concrete_classes.map(&:base_class).uniq
+  end
+
+  private
+  def self.concrete_classes
+    ActiveRecord::Base.descendants.reject {|klass| klass.abstract_class? || !klass.table_exists?}
   end
 end

--- a/test/all_rails_models_test.rb
+++ b/test/all_rails_models_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+describe "all rails tables" do
+  it "includes models that descend from ApplicationRecord" do
+    PartialKs.all_rails_models.must_include User
+  end
+
+  it "excludes abstract classes like ApplicationRecord" do
+    PartialKs.all_rails_models.wont_include ApplicationRecord
+  end
+
+  it "excludes subclass" do
+    PartialKs.all_rails_models.wont_include SubTag
+  end
+
+  it "returns the same number of models as the number of tables" do
+    PartialKs.all_rails_models.map(&:table_name).sort.must_equal ActiveRecord::Base.connection.tables.sort
+  end
+end

--- a/test/setup_models.rb
+++ b/test/setup_models.rb
@@ -1,4 +1,8 @@
-class User < ActiveRecord::Base
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end
+
+class User < ApplicationRecord
   has_many :blog_posts
 end
 
@@ -27,4 +31,7 @@ end
 class NewModel < ActiveRecord::Base
   # no tables, e.g. migration not run yet
   belongs_to :user
+end
+
+class SubTag < Tag
 end


### PR DESCRIPTION
However, because it's a covention we still need to find non abstract classes
that inherit from ActiveRecord::Base as well.

Exclude STI subclass as we don't support STI at the moment