### PR TITLE
Be aware of parent when generating a filter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.6.0 (planned)
+
+Propogate filters down the tree. If the parent downloads the whole table, do the same for the child.
+
 # 0.5.0
 
 * New single entry point, `PartialKs::KitchenSync`. This means that Runner and ConfigurationGenerator are now internal concerns

--- a/lib/partial_ks/filtered_table.rb
+++ b/lib/partial_ks/filtered_table.rb
@@ -1,26 +1,28 @@
 module PartialKs
   class FilteredTable
-    attr_reader :table, :parent_model, :custom_filter_relation
+    attr_reader :table, :parent, :custom_filter_relation
     delegate :table_name, :to => :table
 
-    def initialize(model, parent_model, custom_filter_relation: nil)
+    def initialize(model, parent, custom_filter_relation: nil)
       @table = PartialKs::Table.new(model)
-      @parent_model = parent_model
+      @parent = parent
       @custom_filter_relation = custom_filter_relation
     end
 
     def kitchen_sync_filter
       if custom_filter_relation
         {"only" => filter_based_on_custom_filter_relation}
-      elsif parent_model
-        {"only" => filter_based_on_parent_model}
+      elsif parent && parent.kitchen_sync_filter.nil?
+        nil
+      elsif parent
+        {"only" => filter_based_on_parent_model(parent.table.model)}
       else
         nil
       end
     end
 
     protected
-    def filter_based_on_parent_model
+    def filter_based_on_parent_model(parent_model)
       table.relation_for_associated_model(parent_model).where_sql.to_s.sub(where_regexp, "")
     end
 

--- a/lib/partial_ks/runner.rb
+++ b/lib/partial_ks/runner.rb
@@ -24,16 +24,6 @@ module PartialKs
       end
     end
 
-    def report
-      result = []
-      each_generation.with_index do |generation, depth|
-        generation.each do |table|
-          result << [table.table_name, table.parent.try!(:table).try!(:model), table.custom_filter_relation, depth]
-        end
-      end
-      result
-    end
-
     def each_generation
       return enum_for(:each_generation) unless block_given?
 

--- a/lib/partial_ks/runner.rb
+++ b/lib/partial_ks/runner.rb
@@ -28,7 +28,7 @@ module PartialKs
       result = []
       each_generation.with_index do |generation, depth|
         generation.each do |table|
-          result << [table.table_name, table.parent_model, table.custom_filter_relation, depth]
+          result << [table.table_name, table.parent.try!(:table).try!(:model), table.custom_filter_relation, depth]
         end
       end
       result
@@ -43,9 +43,6 @@ module PartialKs
     end
 
     protected
-    def filtered_tables
-      @filtered_tables ||= models_list.map {|model, parent, custom_filter| PartialKs::FilteredTable.new(model, parent, custom_filter_relation: custom_filter)}
-    end
 
     def generations
       return @generations if defined?(@generations)
@@ -53,8 +50,8 @@ module PartialKs
       @generations = []
       q = []
 
-      filtered_tables.each do |filtered_table|
-        q << filtered_table if filtered_table.parent_model.nil?
+      models_list.each do |model, parent, filter|
+        q << PartialKs::FilteredTable.new(model, nil, custom_filter_relation: filter) if parent.nil?
       end
 
       until q.empty?
@@ -62,8 +59,9 @@ module PartialKs
 
         next_generation = []
         q.each do |table|
-          filtered_tables.each do |child_table|
-            next_generation << child_table if child_table.parent_model && child_table.parent_model.table_name == table.table_name
+          models_list.each do |child_model, parent, filter|
+            # I have access to parent here - link model to child_model
+            next_generation << PartialKs::FilteredTable.new(child_model, table, custom_filter_relation: filter) if parent && parent.table_name == table.table_name
           end
         end
 

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -26,14 +26,6 @@ describe 'running based on output from generator' do
 
   let(:runner) { PartialKs::Runner.new(generator_output) }
 
-  it "reports everything" do
-    runner.report.must_equal [
-      ["users", nil, User.where(:id => [1]), 0],
-      ["tags", nil, nil, 0],
-      ["blog_posts", User, nil, 1],
-    ]
-  end
-
   it "yields all table names" do
     expected_table_names = [User, Tag, BlogPost].map(&:table_name)
     actual_table_names   = []


### PR DESCRIPTION
so that we don't generate huge queries of `where parent_id in <LIST>` where LIST=every id in parent table

Achieved by:
* Passing in a PartialKs::FilteredTable that contains `parent`, rather than a ActiveRecord model
* Modifying runner to achieve the previous point

Simplest solution that will fix #9. 